### PR TITLE
Require spacing around object braces

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -73,6 +73,12 @@
     "no-unused-vars": 2,
     "no-use-before-define": 0,
     "no-with": 2,
+    "object-curly-spacing": [
+      2,
+      "always",
+      {
+      }
+    ],
     "one-var": [
       2,
       "never"


### PR DESCRIPTION
The standard js rules just require that this be consistent (disallows `{ a: b}`), but we should probably pick a hard rule here. Thoughts?

Also why the hell does every single rule have a damn "2" inside of it.